### PR TITLE
Add RB agentic evaluator and Running Back frontend

### DIFF
--- a/backend/agent/rb_agent_graph.py
+++ b/backend/agent/rb_agent_graph.py
@@ -2,57 +2,333 @@
 RB GM Agent — Siddarth Nachannagari
 
 LangGraph agent that evaluates a Running Back free agent and returns a
-SIGN / PASS recommendation based on the predicted grade tier vs. salary ask.
+tiered signing recommendation. Uses the RB model's PFF grade blended with
+an objective stats-based grade (yards/touch, elusive rating, explosive
+run rate, scoring rate), then projects that composite grade — and the
+associated stats — forward year-by-year over the contract, accounting
+for the empirical RB age curve, cap inflation, and time discounting.
 
-Mirrors the pattern from agent_graph.py (QB agent) but uses RBModelInference
-and RB-specific salary valuation anchors.
-
-Usage:
-    from backend.agent.rb_agent_graph import rb_gm_agent, RB_CSV_PATH
-    result = rb_gm_agent.invoke({
-        "player_name": "Saquon Barkley",
-        "salary_ask": 14.0,
-        "player_history": <DataFrame of player's historical seasons>,
-        "predicted_tier": "", "confidence": {}, "valuation": 0.0,
-        "decision": "", "reasoning": ""
-    })
+RBs are the most age-sensitive position in football — the decline starts
+at 27 and accelerates hard after 29. The market values them accordingly.
 """
 
-from typing import TypedDict, Dict
+from typing import TypedDict, Dict, List
 from langgraph.graph import StateGraph, END
 from backend.agent.rb_model_wrapper import RBModelInference
 import pandas as pd
-import os
+import numpy as np
+import os, datetime
 
 # ─────────────────────────────────────────────
 # Paths
 # ─────────────────────────────────────────────
 _BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-RB_CSV_PATH       = os.path.join(_BASE, "ML", "HB.csv")
-RB_TRANSFORMER    = os.path.join(_BASE, "ML", "RB_Pranay_Transformers", "rb_best_classifier.pth")
-RB_SCALER         = os.path.join(_BASE, "ML", "RB_Pranay_Transformers", "rb_player_scaler.joblib")
-RB_XGB            = os.path.join(_BASE, "ML", "RB_Pranay_Transformers", "rb_best_xgb.joblib")
+RB_CSV_PATH    = os.path.join(_BASE, "ML", "HB.csv")
+RB_TRANSFORMER = os.path.join(_BASE, "ML", "RB_Pranay_Transformers", "rb_best_classifier.pth")
+RB_SCALER      = os.path.join(_BASE, "ML", "RB_Pranay_Transformers", "rb_player_scaler.joblib")
+RB_XGB         = os.path.join(_BASE, "ML", "RB_Pranay_Transformers", "rb_best_xgb.joblib")
 
-# Load inference engine once at import time
 rb_engine = RBModelInference(RB_TRANSFORMER, scaler_path=RB_SCALER, xgb_path=RB_XGB)
 
+
 # ─────────────────────────────────────────────
-# RB Salary Valuation Anchors (current NFL market)
+# Grade → Market Value curve (2026 OTC calibrated for RBs)
 #
-# RBs are the most undervalued position in the NFL.
-# These anchors reflect realistic AAV for free-agent contracts
-# based on the 2022-2025 market.
-#
-# FUTURE WORK: Replace with a data-driven market value model
-# trained on historical contract AAV vs. grade outcomes.
+# RBs are the most undervalued position. Top RB contracts currently
+# max out around $18–21M AAV (CMC, Barkley, Henry tier). Starters sit
+# $6–12M, rotational backs $2–4M, depth at veteran minimum.
 # ─────────────────────────────────────────────
-RB_FAIR_VALUE = {
-    "Elite":         18.0,   # Franchise RB — top 10 (e.g., CMC, Barkley level)
-    "Starter":       10.0,   # Reliable starter — above average
-    "Rotation":       4.0,   # Committee back / role player
-    "Reserve/Poor":   1.0,   # Depth / practice squad
+_GRADE_ANCHORS = [45,   55,   60,   65,   70,   75,   80,   85,   90,   95]
+_VALUE_ANCHORS = [0.80, 1.50, 2.50, 4.00, 6.50, 10.0, 14.0, 17.0, 19.5, 22.0]
+
+
+def grade_to_market_value(grade: float) -> float:
+    grade = max(45.0, min(99.0, float(grade)))
+    return round(float(np.interp(grade, _GRADE_ANCHORS, _VALUE_ANCHORS)), 2)
+
+
+# ─────────────────────────────────────────────
+# Stats-based grade equivalent
+#
+# RB production is best captured by efficiency + explosiveness, not
+# raw volume (volume is scheme-dependent). Anchors are empirical
+# medians across the HB.csv.
+#
+# yards_per_touch   — 3.5 reserve, 4.3 rotation, 5.0 starter, 5.9 elite
+# yco_per_attempt   — 1.6, 2.1, 2.7, 3.4
+# elusive_rating    — 30, 50, 75, 110
+# breakaway_percent — 15, 28, 40, 55
+# ─────────────────────────────────────────────
+_YPT_ANCHORS       = [0.0,  3.5,  4.3,  5.0,  5.9,  8.0]
+_YCO_ATT_ANCHORS   = [0.0,  1.6,  2.1,  2.7,  3.4,  5.0]
+_ELUSIVE_ANCHORS   = [0.0, 30.0, 50.0, 75.0, 110.0, 180.0]
+_BREAKAWAY_ANCHORS = [0.0, 15.0, 28.0, 40.0, 55.0, 80.0]
+_STAT_GRD_SCALE    = [45.0, 55.0, 65.0, 75.0, 85.0, 99.0]
+
+
+def _stats_grade(ypt: float, yco_att: float, elusive: float, breakaway: float) -> float:
+    """Map efficiency stats to a 45-99 grade-equivalent score."""
+    a = float(np.interp(ypt,       _YPT_ANCHORS,       _STAT_GRD_SCALE))
+    b = float(np.interp(yco_att,   _YCO_ATT_ANCHORS,   _STAT_GRD_SCALE))
+    c = float(np.interp(elusive,   _ELUSIVE_ANCHORS,   _STAT_GRD_SCALE))
+    d = float(np.interp(breakaway, _BREAKAWAY_ANCHORS, _STAT_GRD_SCALE))
+    return round(0.30 * a + 0.25 * b + 0.25 * c + 0.20 * d, 2)
+
+
+def _composite_grade(model_grade: float, stats_gr: float) -> float:
+    """Blend model PFF grade (40%) with stats-based grade (60%)."""
+    return round(0.40 * model_grade + 0.60 * stats_gr, 2)
+
+
+def _grade_to_tier(grade: float) -> str:
+    if grade >= 80: return "Elite"
+    if grade >= 70: return "Starter"
+    if grade >= 60: return "Rotation"
+    return "Reserve/Poor"
+
+
+# ─────────────────────────────────────────────
+# Age-based annual grade delta for RBs
+#
+# RBs age the fastest of any position. Peak is 24-26, then decline
+# is rapid and non-linear. Calibrated from empirical RB season
+# transitions.
+# ─────────────────────────────────────────────
+_AGE_DELTAS = {
+    20: +3.5, 21: +3.0, 22: +2.5, 23: +1.5, 24: +0.5,
+    25: -0.3, 26: -1.5, 27: -2.8, 28: -4.0, 29: -5.5,
+    30: -7.0, 31: -8.5, 32: -10.0, 33: -10.0, 34: -10.0,
 }
+
+
+def _annual_grade_delta(age: int) -> float:
+    if age <= 20: return +3.5
+    if age >= 35: return -10.0
+    return _AGE_DELTAS.get(age, -5.0)
+
+
+# ─────────────────────────────────────────────
+# Stats extraction helpers
+# ─────────────────────────────────────────────
+def _safe_float(val, default=0.0) -> float:
+    try:
+        f = float(val)
+        return default if np.isnan(f) else f
+    except Exception:
+        return default
+
+
+def _has_valid_stats(row) -> bool:
+    """Return True if a row has at least one key counting stat."""
+    for col in ("total_touches", "yards", "attempts", "receptions"):
+        val = row.get(col)
+        try:
+            f = float(val)
+            if not np.isnan(f) and f > 0:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def _season_stats_row(row) -> dict:
+    """Pull display stats for a single season row."""
+    year     = int(_safe_float(row.get("Year"), 2024))
+    attempts = _safe_float(row.get("attempts"))
+    yards    = _safe_float(row.get("yards"))
+    yco      = _safe_float(row.get("yards_after_contact"))
+    yco_att  = _safe_float(row.get("yco_attempt"))
+    touches  = _safe_float(row.get("total_touches"))
+    tds      = _safe_float(row.get("touchdowns"))
+    receptions = _safe_float(row.get("receptions"))
+    rec_yards  = _safe_float(row.get("rec_yards"))
+    targets    = _safe_float(row.get("targets"))
+    elusive    = _safe_float(row.get("elusive_rating"))
+    breakaway  = _safe_float(row.get("breakaway_percent"))
+    explosive  = _safe_float(row.get("explosive"))
+    first_downs = _safe_float(row.get("first_downs"))
+    fumbles    = _safe_float(row.get("fumbles"))
+    ypa        = _safe_float(row.get("ypa"))
+    yprr       = _safe_float(row.get("yprr"))
+    overall    = _safe_float(row.get("grades_offense"))
+    run_gr     = _safe_float(row.get("grades_run"))
+    pass_gr    = _safe_float(row.get("grades_pass_route"))
+
+    ypt = round(yards / touches, 2) if touches > 0 else 0.0
+
+    return {
+        "season":          year,
+        "attempts":        int(attempts),
+        "yards":           int(yards),
+        "yards_after_contact": int(yco),
+        "yco_per_attempt": round(yco_att, 2),
+        "ypa":             round(ypa, 2),
+        "total_touches":   int(touches),
+        "touchdowns":      int(tds),
+        "receptions":      int(receptions),
+        "rec_yards":       int(rec_yards),
+        "targets":         int(targets),
+        "yards_per_touch": ypt,
+        "elusive_rating":  round(elusive, 1),
+        "breakaway_pct":   round(breakaway, 1),
+        "explosive":       int(explosive),
+        "first_downs":     int(first_downs),
+        "fumbles":         int(fumbles),
+        "yprr":            round(yprr, 2),
+        "run_grade":       round(run_gr, 1),
+        "pass_grade":      round(pass_gr, 1),
+        "overall_grade":   round(overall, 1),
+    }
+
+
+def extract_career_stats(history: pd.DataFrame) -> List[dict]:
+    """Return per-season stats for every recorded season that has data."""
+    seasons = []
+    for _, row in history.sort_values("Year").iterrows():
+        if not _has_valid_stats(row):
+            continue
+        seasons.append(_season_stats_row(row))
+    return seasons
+
+
+def extract_last_season_stats(history: pd.DataFrame) -> dict:
+    """Pull the most recent season with actual data."""
+    sorted_hist = history.sort_values("Year")
+    valid_rows = sorted_hist[sorted_hist.apply(_has_valid_stats, axis=1)]
+    if valid_rows.empty:
+        valid_rows = sorted_hist
+
+    row = valid_rows.iloc[-1]
+    stats = _season_stats_row(row)
+
+    # Career-weighted efficiency rates (sample-size-resistant)
+    c_yards = c_touches = c_yco = c_attempts = c_tds = 0.0
+    c_elusive = c_breakaway = 0.0
+    n = 0
+    for _, r in valid_rows.iterrows():
+        att = _safe_float(r.get("attempts"))
+        c_yards    += _safe_float(r.get("yards"))
+        c_touches  += _safe_float(r.get("total_touches"))
+        c_yco      += _safe_float(r.get("yards_after_contact"))
+        c_attempts += att
+        c_tds      += _safe_float(r.get("touchdowns"))
+        c_elusive   += _safe_float(r.get("elusive_rating"))
+        c_breakaway += _safe_float(r.get("breakaway_percent"))
+        n += 1
+
+    career_ypt       = c_yards / c_touches if c_touches > 0 else 0.0
+    career_yco_att   = c_yco   / c_attempts if c_attempts > 0 else 0.0
+    career_elusive   = c_elusive   / n if n > 0 else 0.0
+    career_breakaway = c_breakaway / n if n > 0 else 0.0
+
+    stats["career_ypt"]       = round(career_ypt, 2)
+    stats["career_yco_att"]   = round(career_yco_att, 2)
+    stats["career_elusive"]   = round(career_elusive, 1)
+    stats["career_breakaway"] = round(career_breakaway, 1)
+
+    return stats
+
+
+# ─────────────────────────────────────────────
+# Stat projection forward over contract
+# ─────────────────────────────────────────────
+def project_stats(last_stats: dict, composite_gr: float,
+                  current_age: int, contract_years: int) -> List[dict]:
+    """
+    Project RB stats forward year-by-year. Each year's projected grade
+    scales the previous season's key counting stats.
+    """
+    projections = []
+    grade = composite_gr
+
+    for yr in range(1, contract_years + 1):
+        age = current_age + yr - 1
+        if yr > 1:
+            grade = max(45.0, min(99.0, grade + _annual_grade_delta(age - 1)))
+
+        scale = max(0.25, min(1.4, grade / composite_gr)) if composite_gr > 0 else 1.0
+
+        projections.append({
+            "year":             yr,
+            "age":              age,
+            "projected_grade":  round(grade, 1),
+            "attempts":         int(round(last_stats["attempts"]      * scale)),
+            "yards":            int(round(last_stats["yards"]         * scale)),
+            "yards_per_touch":  round(min(8.0,  last_stats["yards_per_touch"] * ((scale + 1) / 2)), 2),
+            "yco_per_attempt":  round(min(5.0,  last_stats["yco_per_attempt"] * ((scale + 1) / 2)), 2),
+            "touchdowns":       int(round(last_stats["touchdowns"]    * scale)),
+            "receptions":       int(round(last_stats["receptions"]    * scale)),
+            "rec_yards":        int(round(last_stats["rec_yards"]     * scale)),
+            "elusive_rating":   round(min(180.0, last_stats["elusive_rating"] * ((scale + 1) / 2)), 1),
+            "breakaway_pct":    round(min(80.0,  last_stats["breakaway_pct"]  * ((scale + 1) / 2)), 1),
+            "run_grade":        round(min(99.0, last_stats["run_grade"]  * scale), 1),
+            "overall_grade":    round(grade, 1),
+        })
+
+    return projections
+
+
+# ─────────────────────────────────────────────
+# Contract-adjusted valuation
+# ─────────────────────────────────────────────
+DISCOUNT_RATE   = 0.08   # 8%/yr — roster uncertainty & cap risk
+CAP_GROWTH_RATE = 0.065  # 6.5%/yr — historical NFL cap growth
+
+
+def compute_contract_value(
+    composite_gr: float,
+    current_age: int,
+    contract_years: int,
+    salary_ask: float,
+) -> tuple:
+    """
+    Returns:
+        fair_aav             – PV of cap-inflated player value / yr
+        effective_cap_burden – PV of cap-adjusted ask / yr
+        total_nominal_value  – sum of nominal player values
+        breakdown            – per-year dicts
+    """
+    breakdown           = []
+    total_disc_value    = 0.0
+    total_disc_ask      = 0.0
+    total_nominal_value = 0.0
+    grade               = float(composite_gr)
+
+    for yr in range(1, contract_years + 1):
+        age = current_age + yr - 1
+        if yr > 1:
+            grade = max(45.0, min(99.0, grade + _annual_grade_delta(age - 1)))
+
+        cap_factor    = (1.0 + CAP_GROWTH_RATE) ** (yr - 1)
+        time_discount = 1.0 / ((1.0 + DISCOUNT_RATE)   ** (yr - 1))
+
+        base_value    = grade_to_market_value(grade)
+        nominal_value = base_value * cap_factor
+        disc_value    = nominal_value * time_discount
+
+        cap_adj_ask   = salary_ask / cap_factor
+        disc_ask      = cap_adj_ask * time_discount
+        year_surplus  = round(base_value - cap_adj_ask, 2)
+
+        total_nominal_value += nominal_value
+        total_disc_value    += disc_value
+        total_disc_ask      += disc_ask
+
+        breakdown.append({
+            "year":             yr,
+            "age":              age,
+            "projected_grade":  round(grade, 1),
+            "market_value":     base_value,
+            "nominal_value":    round(nominal_value, 2),
+            "cap_adj_ask":      round(cap_adj_ask, 2),
+            "discounted_value": round(disc_value, 2),
+            "year_surplus":     year_surplus,
+        })
+
+    fair_aav             = round(total_disc_value / contract_years, 2)
+    effective_cap_burden = round(total_disc_ask   / contract_years, 2)
+    return fair_aav, effective_cap_burden, round(total_nominal_value, 2), breakdown
 
 
 # ─────────────────────────────────────────────
@@ -60,38 +336,81 @@ RB_FAIR_VALUE = {
 # ─────────────────────────────────────────────
 class RBAgentState(TypedDict):
     # Inputs
-    player_name:    str
-    salary_ask:     float           # in millions (AAV)
-    player_history: pd.DataFrame   # raw historical seasons from HB.csv
+    player_name:     str
+    salary_ask:      float
+    contract_years:  int
+    player_history:  pd.DataFrame
 
-    # Outputs (populated by graph nodes)
-    predicted_tier: str
-    confidence:     Dict[str, float]
-    valuation:      float           # estimated fair market value (millions)
-    decision:       str             # "SIGN" or "PASS"
-    reasoning:      str
+    # Populated by predict_performance
+    predicted_tier:    str
+    confidence:        Dict[str, float]
+    current_age:       int
+    last_season_stats: dict
+    career_stats:      List[dict]
+    stats_score:       float
+    composite_grade:   float
+
+    # Populated by evaluate_value
+    valuation:            float
+    effective_cap_burden: float
+    total_nominal_value:  float
+    year_breakdown:       List[dict]
+    projected_stats:      List[dict]
+
+    # Populated by make_decision
+    decision:  str
+    reasoning: str
 
 
 # ─────────────────────────────────────────────
 # Node 1: Predict Performance
 # ─────────────────────────────────────────────
 def predict_performance(state: RBAgentState):
-    """Run the RB ensemble model to predict tier and confidence details."""
     print(f"[RB Agent] Predicting performance for {state['player_name']}...")
 
     tier, details = rb_engine.get_prediction(state["player_history"], apply_calibration=True)
+    model_grade   = float(details.get("predicted_grade", 60.0))
+
+    history      = state["player_history"]
+    current_year = datetime.date.today().year
+    if "age" in history.columns and "Year" in history.columns:
+        last_row           = history.sort_values("Year").iloc[-1]
+        age_at_last_season = int(_safe_float(last_row["age"], 26))
+        last_season_year   = int(_safe_float(last_row["Year"], current_year - 1))
+        current_age        = age_at_last_season + (current_year - last_season_year)
+    else:
+        current_age = 26
+
+    last_stats   = extract_last_season_stats(history)
+    career_stats = extract_career_stats(history)
+
+    # Stats grade uses career-weighted efficiency metrics
+    sg = _stats_grade(
+        last_stats.get("career_ypt",       last_stats["yards_per_touch"]),
+        last_stats.get("career_yco_att",   last_stats["yco_per_attempt"]),
+        last_stats.get("career_elusive",   last_stats["elusive_rating"]),
+        last_stats.get("career_breakaway", last_stats["breakaway_pct"]),
+    )
+
+    cg = _composite_grade(model_grade, sg)
+    cg = round(max(45.0, min(99.0, cg)), 2)
 
     return {
-        "predicted_tier": tier,
+        "predicted_tier":    _grade_to_tier(cg),
+        "current_age":       current_age,
+        "last_season_stats": last_stats,
+        "career_stats":      career_stats,
+        "stats_score":       sg,
+        "composite_grade":   cg,
         "confidence": {
-            "predicted_grade":    details.get("predicted_grade"),
-            "xgb_grade":          details.get("xgb_grade"),
-            "transformer_grade":  details.get("transformer_grade"),
-            "age_adjustment":     details.get("age_adjustment"),
-            "volatility_index":   details.get("volatility_index"),
-            "conf_lower":         details.get("confidence_interval", (None, None))[0],
-            "conf_upper":         details.get("confidence_interval", (None, None))[1],
-        }
+            "model_grade":       float(round(model_grade, 2)),
+            "stats_grade":       float(sg),
+            "composite_grade":   float(cg),
+            "xgb_grade":         float(details["xgb_grade"]) if details.get("xgb_grade") is not None else None,
+            "transformer_grade": float(details["transformer_grade"]) if details.get("transformer_grade") is not None else None,
+            "age_adjustment":    float(details["age_adjustment"]) if details.get("age_adjustment") is not None else None,
+            "volatility_index":  float(details["volatility_index"]) if details.get("volatility_index") is not None else None,
+        },
     }
 
 
@@ -99,46 +418,95 @@ def predict_performance(state: RBAgentState):
 # Node 2: Evaluate Value
 # ─────────────────────────────────────────────
 def evaluate_value(state: RBAgentState):
-    """Map predicted tier to an estimated fair market value."""
-    tier = state["predicted_tier"]
-    fair_value = RB_FAIR_VALUE.get(tier, 1.0)
-    return {"valuation": fair_value}
+    cg             = state["composite_grade"]
+    current_age    = state["current_age"]
+    contract_years = state["contract_years"]
+    salary_ask     = state["salary_ask"]
+
+    fair_aav, eff_burden, total_nom, breakdown = compute_contract_value(
+        cg, current_age, contract_years, salary_ask
+    )
+
+    stat_proj = project_stats(
+        state["last_season_stats"], cg, current_age, contract_years
+    )
+
+    return {
+        "valuation":            fair_aav,
+        "effective_cap_burden": eff_burden,
+        "total_nominal_value":  total_nom,
+        "year_breakdown":       breakdown,
+        "projected_stats":      stat_proj,
+    }
 
 
 # ─────────────────────────────────────────────
 # Node 3: Make Decision
 # ─────────────────────────────────────────────
 def make_decision(state: RBAgentState):
-    """Return SIGN or PASS based on salary ask vs. fair value."""
-    ask   = state["salary_ask"]
-    val   = state["valuation"]
-    tier  = state["predicted_tier"]
-    grade = state["confidence"].get("predicted_grade", "N/A")
-    vol   = state["confidence"].get("volatility_index", None)
-    lower = state["confidence"].get("conf_lower")
-    upper = state["confidence"].get("conf_upper")
+    ask    = state["salary_ask"]
+    val    = state["valuation"]
+    burden = state["effective_cap_burden"]
+    tier   = state["predicted_tier"]
+    cg     = state["composite_grade"]
+    mg     = state["confidence"].get("model_grade", cg)
+    sg     = state["stats_score"]
+    age    = state["current_age"]
+    years  = state["contract_years"]
+    total  = state["total_nominal_value"]
+    adj    = state["confidence"].get("age_adjustment")
 
-    conf_str = f" (grade range: {lower}–{upper})" if lower is not None else ""
-    vol_str  = f", volatility index: {vol:.2f}" if vol is not None else ""
+    adj_str = f", age penalty: -{adj} pts" if adj else ""
 
-    if ask <= val:
-        decision = "SIGN"
-        surplus  = round(val - ask, 1)
-        reason   = (
-            f"{state['player_name']} projects as a {tier} RB "
-            f"(predicted grade: {grade}{conf_str}{vol_str}). "
-            f"Estimated fair value is ${val}M/yr — asking ${ask}M/yr is a "
-            f"surplus value of ${surplus}M. Recommend signing."
-        )
+    if age <= 24:   trajectory = "still ascending toward his peak"
+    elif age <= 26: trajectory = "in his prime years"
+    elif age <= 28: trajectory = "at the edge of his prime — decline is imminent"
+    elif age <= 30: trajectory = "in post-prime decline — the cliff is near"
+    else:           trajectory = "past the RB cliff and in steep decline"
+
+    total_ask = round(ask * years, 2)
+    cap_note  = (
+        f"With ~{int(CAP_GROWTH_RATE*100)}%/yr cap growth the fixed ${ask}M AAV "
+        f"costs effectively ${burden}M/yr in present-value cap terms."
+    )
+
+    surplus     = round(val - burden, 2)
+    surplus_pct = (val - burden) / max(val, 0.01) * 100
+
+    if surplus_pct >= 20:
+        decision    = "Exceptional Value"
+        verdict_str = f"surplus of ${surplus}M/yr ({surplus_pct:.0f}% below fair value) — an exceptional deal."
+        rec         = "Strongly recommend signing immediately."
+    elif surplus_pct >= 5:
+        decision    = "Good Signing"
+        verdict_str = f"surplus of ${surplus}M/yr — good value at this price."
+        rec         = "Recommend signing."
+    elif surplus_pct >= -5:
+        decision    = "Fair Deal"
+        verdict_str = f"${abs(surplus)}M/yr {'surplus' if surplus >= 0 else 'overpay'} — roughly market rate."
+        rec         = "Acceptable signing at or near fair value."
+    elif surplus_pct >= -15:
+        decision    = "Slight Overpay"
+        verdict_str = f"overpay of ${abs(surplus)}M/yr ({abs(surplus_pct):.0f}% above fair value) — modest premium."
+        rec         = "Manageable overpay; proceed with caution."
+    elif surplus_pct >= -30:
+        decision    = "Overpay"
+        verdict_str = f"overpay of ${abs(surplus)}M/yr ({abs(surplus_pct):.0f}% above fair value) — significant premium."
+        rec         = "Recommend passing unless positional need is critical."
     else:
-        decision = "PASS"
-        overpay  = round(ask - val, 1)
-        reason   = (
-            f"{state['player_name']} projects as a {tier} RB "
-            f"(predicted grade: {grade}{conf_str}{vol_str}). "
-            f"Estimated fair value is ${val}M/yr — asking ${ask}M/yr is an "
-            f"overpay of ${overpay}M. Recommend passing."
-        )
+        decision    = "Poor Signing"
+        verdict_str = f"overpay of ${abs(surplus)}M/yr ({abs(surplus_pct):.0f}% above fair value) — severely overpriced."
+        rec         = "Strongly recommend passing."
+
+    reason = (
+        f"{state['player_name']} (age {age}) projects as a {tier} running back. "
+        f"Model grade: {mg:.1f} · Stats grade (efficiency basis): {sg:.1f} → "
+        f"Composite: {cg:.1f}{adj_str}. He is {trajectory}. "
+        f"Over a {years}-yr contract the composite projects a cap-inflation-adjusted "
+        f"fair value of ${val}M/yr vs. an effective cap burden of ${burden}M/yr — "
+        f"{verdict_str} {cap_note} Total nominal player value: ${total}M vs. total ask: "
+        f"${total_ask}M. {rec}"
+    )
 
     return {"decision": decision, "reasoning": reason}
 
@@ -147,15 +515,11 @@ def make_decision(state: RBAgentState):
 # Graph Construction
 # ─────────────────────────────────────────────
 _workflow = StateGraph(RBAgentState)
-
 _workflow.add_node("predict_performance", predict_performance)
 _workflow.add_node("evaluate_value",      evaluate_value)
 _workflow.add_node("make_decision",       make_decision)
-
 _workflow.set_entry_point("predict_performance")
-
 _workflow.add_edge("predict_performance", "evaluate_value")
 _workflow.add_edge("evaluate_value",      "make_decision")
 _workflow.add_edge("make_decision",       END)
-
 rb_gm_agent = _workflow.compile()

--- a/backend/agent/rb_main_api.py
+++ b/backend/agent/rb_main_api.py
@@ -1,0 +1,129 @@
+"""
+RB GM Agent API
+
+FastAPI endpoint for evaluating Running Back free agents.
+Accepts player name, salary ask (AAV), and contract length in years.
+
+Usage:
+    uvicorn backend.agent.rb_main_api:app --host 0.0.0.0 --port 8004
+    POST /evaluate  {"player_name": "Saquon Barkley", "salary_ask": 14.0, "contract_years": 3}
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+_thread_pool = ThreadPoolExecutor(max_workers=2)
+from backend.agent.rb_agent_graph import rb_gm_agent, RB_CSV_PATH
+import pandas as pd
+import uvicorn
+import os
+
+app = FastAPI(title="NFL RB GM Agent API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Load player data once at startup
+if os.path.exists(RB_CSV_PATH):
+    df_players = pd.read_csv(RB_CSV_PATH)
+    if "player" not in df_players.columns:
+        for candidate in ["Player", "Name", "name"]:
+            if candidate in df_players.columns:
+                df_players.rename(columns={candidate: "player"}, inplace=True)
+                break
+    print(f"[RB API] Loaded player database: {len(df_players)} rows")
+else:
+    print(f"WARNING: RB player CSV not found at {RB_CSV_PATH}.")
+    df_players = pd.DataFrame()
+
+
+@app.get("/rb-players")
+async def get_rb_players():
+    """Return sorted list of all RB player names available for evaluation."""
+    if df_players.empty:
+        raise HTTPException(status_code=503, detail="Player database not loaded.")
+    names = sorted(df_players["player"].dropna().unique().tolist())
+    return {"players": names}
+
+
+class EvaluationRequest(BaseModel):
+    player_name:    str
+    salary_ask:     float           # AAV in $M
+    contract_years: int = Field(default=1, ge=1, le=10)
+
+
+@app.post("/evaluate")
+async def evaluate_player(req: EvaluationRequest):
+    """
+    Evaluate a Running Back free agent.
+
+    Runs the RB GM agent workflow accounting for contract length,
+    RB-specific age-based performance decay, cap growth, and time
+    discounting. Returns a tiered recommendation with per-year
+    breakdown and projected stats.
+    """
+    player_data = df_players[df_players["player"] == req.player_name].copy()
+
+    if len(player_data) == 0:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Player '{req.player_name}' not found in database.",
+        )
+
+    initial_state = {
+        "player_name":    req.player_name,
+        "salary_ask":     req.salary_ask,
+        "contract_years": req.contract_years,
+        "player_history": player_data,
+        "predicted_tier":    "",
+        "confidence":        {},
+        "current_age":       26,
+        "last_season_stats": {},
+        "career_stats":      [],
+        "stats_score":       0.0,
+        "composite_grade":   0.0,
+        "valuation":            0.0,
+        "effective_cap_burden": 0.0,
+        "total_nominal_value":  0.0,
+        "year_breakdown":    [],
+        "projected_stats":   [],
+        "decision":          "",
+        "reasoning":         "",
+    }
+
+    loop = asyncio.get_event_loop()
+    final_state = await loop.run_in_executor(
+        _thread_pool, rb_gm_agent.invoke, initial_state
+    )
+
+    return {
+        "player":    req.player_name,
+        "decision":  final_state["decision"],
+        "reasoning": final_state["reasoning"],
+        "data": {
+            "predicted_tier":       final_state["predicted_tier"],
+            "current_age":          final_state["current_age"],
+            "contract_years":       req.contract_years,
+            "effective_fair_aav":   final_state["valuation"],
+            "effective_cap_burden": final_state["effective_cap_burden"],
+            "total_nominal_value":  final_state["total_nominal_value"],
+            "total_ask":            round(req.salary_ask * req.contract_years, 2),
+            "confidence":           final_state["confidence"],
+            "year_breakdown":       final_state["year_breakdown"],
+            "last_season_stats":    final_state["last_season_stats"],
+            "projected_stats":      final_state["projected_stats"],
+            "career_stats":         final_state["career_stats"],
+        },
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8004)

--- a/frontend/src/pages/FreeAgency.jsx
+++ b/frontend/src/pages/FreeAgency.jsx
@@ -3,6 +3,7 @@ import './FreeAgency.css';
 
 const ED_API = 'http://127.0.0.1:8002';
 const DI_API = 'http://127.0.0.1:8003';
+const RB_API = 'http://127.0.0.1:8004';
 
 /* ─── Searchable Select (combobox) ─── */
 function SearchableSelect({ options, value, onChange, placeholder = 'Search…' }) {
@@ -76,7 +77,7 @@ function SearchableSelect({ options, value, onChange, placeholder = 'Search…' 
 
 const POSITIONS = [
   { label: 'QB',  name: 'Quarterback',       available: false },
-  { label: 'HB',  name: 'Running Back',       available: false },
+  { label: 'HB',  name: 'Running Back',       available: true  },
   { label: 'WR',  name: 'Wide Receiver',      available: false },
   { label: 'TE',  name: 'Tight End',          available: false },
   { label: 'T',   name: 'Tackle',             available: false },
@@ -1357,6 +1358,329 @@ function DIEvaluator({ onBack }) {
   );
 }
 
+/* ─── RB Evaluator ─── */
+const RB_STAT_ROWS = [
+  { key: 'attempts',        label: 'Attempts' },
+  { key: 'yards',           label: 'Rushing Yards' },
+  { key: 'yards_per_touch', label: 'Yds / Touch' },
+  { key: 'yco_per_attempt', label: 'YCO / Att' },
+  { key: 'touchdowns',      label: 'Touchdowns' },
+  { key: 'receptions',      label: 'Receptions' },
+  { key: 'rec_yards',       label: 'Rec Yards' },
+  { key: 'elusive_rating',  label: 'Elusive Rating' },
+  { key: 'breakaway_pct',   label: 'Breakaway %',  fmt: v => `${v}%` },
+  { key: 'run_grade',       label: 'Run Grade' },
+  { key: 'overall_grade',   label: 'Overall Grade' },
+];
+
+function RBStatsPanel({ careerStats, projectedStats }) {
+  const lastCareer = careerStats[careerStats.length - 1];
+  return (
+    <div className="fa-stats-panel">
+      <p className="fa-stats-panel-title">Career Stats + Projection</p>
+      <div className="fa-stats-scroll">
+        <table className="fa-stats-tbl">
+          <thead>
+            <tr>
+              <th className="fa-stats-row-hdr">Stat</th>
+              {careerStats.map(s => (
+                <th key={s.season} className="fa-stats-col-career">
+                  <div className="fa-stats-col-hdr">{s.season}</div>
+                  <div className="fa-stats-col-sub">{s.total_touches} touch</div>
+                </th>
+              ))}
+              {projectedStats.map(yr => (
+                <th key={`proj-${yr.year}`} className="fa-stats-col-proj">
+                  <div className="fa-stats-col-hdr">Yr {yr.year}</div>
+                  <div className="fa-stats-col-sub">Age {yr.age}</div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {RB_STAT_ROWS.map(({ key, label, fmt }) => (
+              <tr key={key}>
+                <td className="fa-stats-row-hdr">{label}</td>
+                {careerStats.map(s => (
+                  <td key={s.season} className="fa-stats-career-cell">
+                    {s[key] != null ? (fmt ? fmt(s[key]) : s[key]) : '—'}
+                  </td>
+                ))}
+                {projectedStats.map(yr => {
+                  const val = key === 'overall_grade' ? (yr[key] ?? yr['projected_grade']) : yr[key];
+                  const last = lastCareer?.[key];
+                  const delta = (val != null && last != null && last !== 0 && key !== 'overall_grade')
+                    ? (val - last) : null;
+                  return (
+                    <td key={yr.year} className={
+                      delta == null ? '' : delta > 0.05 ? 'fa-stat-up' : delta < -0.05 ? 'fa-stat-down' : ''
+                    }>
+                      {val != null ? (fmt ? fmt(val) : val) : '—'}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="fa-breakdown-note">
+        Career columns show actual per-season totals. Projected years scale counting stats by the composite grade trajectory.
+        Composite = 40% model PFF grade + 60% stats-based grade (yards/touch, YCO/att, elusive rating, breakaway %).
+        RB age curve declines sharply after 28 — projections reflect this.
+      </p>
+    </div>
+  );
+}
+
+function RBEvaluator({ onBack }) {
+  const [players, setPlayers] = useState([]);
+  const [selectedPlayer, setSelectedPlayer] = useState('');
+  const [salaryAsk, setSalaryAsk] = useState('');
+  const [contractYears, setContractYears] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [fetchingPlayers, setFetchingPlayers] = useState(true);
+  const [messages, setMessages] = useState([{
+    role: 'assistant',
+    content:
+      'Welcome to the Running Back Free Agency Evaluator. RBs are the most age-sensitive position in football — the decline starts at 27 and accelerates hard after 29. Select a player, set the contract AAV and length, then click Analyze for a recommendation.',
+  }]);
+  const [error, setError] = useState('');
+  const [statsOpen, setStatsOpen] = useState({});
+
+  const chatEndRef = useRef(null);
+
+  const toggleStats = useCallback((i) => {
+    setStatsOpen(prev => ({ ...prev, [i]: !prev[i] }));
+  }, []);
+
+  useEffect(() => {
+    fetch(`${RB_API}/rb-players`)
+      .then(r => r.json())
+      .then(data => {
+        setPlayers(data.players || []);
+        setSelectedPlayer(data.players?.[0] || '');
+      })
+      .catch(() => setError('Could not load player list. Make sure the RB API is running on port 8004.'))
+      .finally(() => setFetchingPlayers(false));
+  }, []);
+
+  useEffect(() => { chatEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
+
+  const buildStructured = (result, ask, years) => {
+    const { decision, reasoning, data } = result;
+    const {
+      predicted_tier, current_age, effective_fair_aav, effective_cap_burden,
+      total_nominal_value, total_ask, confidence, year_breakdown,
+      last_season_stats, projected_stats, career_stats,
+    } = data;
+    const { model_grade, stats_grade, composite_grade,
+            transformer_grade, xgb_grade, age_adjustment, volatility_index } = confidence || {};
+
+    const statRows = [
+      { divider: true, title: 'Player Profile' },
+      { label: 'Projected Tier',        value: predicted_tier },
+      { label: 'Current Age',           value: current_age },
+      { divider: true, title: 'Grade Breakdown' },
+      { label: 'Model Grade',           value: model_grade != null ? `${Number(model_grade).toFixed(1)} / 100` : 'N/A' },
+      { label: 'Stats Grade',           value: stats_grade != null ? `${Number(stats_grade).toFixed(1)} / 100` : 'N/A' },
+      { label: 'Composite Grade',       value: composite_grade != null ? `${Number(composite_grade).toFixed(1)} / 100` : 'N/A' },
+    ];
+    if (transformer_grade != null)
+      statRows.push({ label: 'Transformer Grade', value: Number(transformer_grade).toFixed(1) });
+    if (xgb_grade != null)
+      statRows.push({ label: 'XGBoost Grade', value: Number(xgb_grade).toFixed(1) });
+    if (age_adjustment != null && age_adjustment !== 0)
+      statRows.push({ label: 'Age Penalty (applied)', value: `-${Number(age_adjustment).toFixed(1)} pts` });
+    if (volatility_index != null)
+      statRows.push({ label: 'Volatility Index', value: Number(volatility_index).toFixed(2) });
+
+    statRows.push(
+      { divider: true, title: 'Contract Valuation' },
+      { label: 'Contract',              value: `$${ask}M/yr × ${years} yr  =  $${total_ask}M total` },
+      { label: 'Fair AAV (cap-adj PV)', value: `$${effective_fair_aav}M / yr` },
+      { label: 'Real Cap Burden (PV)',  value: `$${effective_cap_burden}M / yr` },
+      { label: 'Total Nominal Value',   value: `$${total_nominal_value}M` },
+    );
+
+    return {
+      decision,
+      highlight: DECISION_CLASS[decision] || 'fair',
+      signing_grade: signingGradeFromData(effective_fair_aav, effective_cap_burden, null),
+      tier_description: TIER_DESCRIPTION[decision] || '',
+      stats: statRows,
+      reasoning,
+      year_breakdown,
+      last_season_stats,
+      projected_stats,
+      career_stats: career_stats || [],
+    };
+  };
+
+  const handleAnalyze = async () => {
+    if (!selectedPlayer) return;
+    const ask = parseFloat(salaryAsk);
+    if (isNaN(ask) || ask <= 0) { setError('Please enter a valid salary (positive number in $M).'); return; }
+    setError('');
+
+    setMessages(prev => [...prev, {
+      role: 'user',
+      content: `Evaluate ${selectedPlayer} — $${ask}M/yr × ${contractYears} yr contract.`,
+    }]);
+    setLoading(true);
+    try {
+      const resp = await fetch(`${RB_API}/evaluate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          player_name: selectedPlayer,
+          salary_ask: ask,
+          contract_years: contractYears,
+        }),
+      });
+      if (!resp.ok) { const err = await resp.json(); throw new Error(err.detail || 'Evaluation failed.'); }
+      const result = await resp.json();
+      setMessages(prev => [...prev, {
+        role: 'assistant', content: null,
+        structured: buildStructured(result, ask, contractYears),
+      }]);
+    } catch (e) {
+      setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${e.message}` }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fa-page">
+      <div className="fa-panel">
+        <button className="fa-back-btn" onClick={onBack}>← Change Position</button>
+        <h2 className="fa-panel-title">Running Back Scout</h2>
+
+        <div className="fa-field">
+          <label className="fa-label">Player</label>
+          {fetchingPlayers ? <p className="fa-hint">Loading players…</p> : (
+            <SearchableSelect
+              options={players}
+              value={selectedPlayer}
+              onChange={setSelectedPlayer}
+              placeholder="Search players…"
+            />
+          )}
+        </div>
+
+        <div className="fa-field">
+          <label className="fa-label">Contract AAV ($M / yr)</label>
+          <div className="fa-price-row">
+            <span className="fa-dollar">$</span>
+            <input type="number" min="0" step="0.5" className="fa-input" placeholder="e.g. 10.0"
+              value={salaryAsk} onChange={e => setSalaryAsk(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleAnalyze()} />
+            <span className="fa-million">M</span>
+          </div>
+        </div>
+
+        <div className="fa-field">
+          <label className="fa-label">Contract Length — {contractYears} yr</label>
+          <input type="range" min="1" max="7" step="1" className="fa-slider"
+            value={contractYears} onChange={e => setContractYears(Number(e.target.value))} />
+          <div className="fa-slider-ticks">
+            {[1,2,3,4,5,6,7].map(n => (
+              <span key={n} className={n === contractYears ? 'fa-tick fa-tick--active' : 'fa-tick'}
+                onClick={() => setContractYears(n)}>{n}</span>
+            ))}
+          </div>
+        </div>
+
+        {error && <p className="fa-error">{error}</p>}
+
+        <button className="fa-btn" onClick={handleAnalyze}
+          disabled={loading || fetchingPlayers || !selectedPlayer}>
+          {loading ? 'Analyzing…' : 'Analyze Player'}
+        </button>
+
+        <div className="fa-legend">
+          <p className="fa-legend-title">2026 Market Ranges (RB)</p>
+          <div className="fa-legend-row"><span className="tier-badge elite">Elite</span><span>$14–22M</span></div>
+          <div className="fa-legend-row"><span className="tier-badge starter">Starter</span><span>$6–14M</span></div>
+          <div className="fa-legend-row"><span className="tier-badge rotation">Rotation</span><span>$2–6M</span></div>
+          <div className="fa-legend-row"><span className="tier-badge reserve">Reserve</span><span>&lt;$2M</span></div>
+          <p className="fa-legend-note">
+            RBs are the most age-sensitive position — decline accelerates after 28.<br/>
+            Composite blends 40% model PFF grade + 60% efficiency stats.<br/>
+            Future years discounted at 8%/yr.
+          </p>
+        </div>
+
+        <DecisionTierLegend teamMode={false} />
+      </div>
+
+      <div className="fa-chat">
+        <div className="fa-chat-header">GM Decision Feed — Running Back</div>
+        <div className="fa-chat-body">
+          {messages.map((msg, i) => (
+            <div key={i} className={`fa-msg fa-msg--${msg.role}`}>
+              <div className="fa-msg-label">{msg.role === 'user' ? 'You' : 'GM Agent'}</div>
+              {msg.content != null ? (
+                <div className="fa-msg-text">{msg.content}</div>
+              ) : (
+                <div className="fa-msg-card">
+                  <div className={`fa-decision-badge ${msg.structured.highlight}`}>
+                    {msg.structured.decision}
+                  </div>
+                  <SigningGrade grade={msg.structured.signing_grade} />
+                  {msg.structured.tier_description && (
+                    <div className="fa-tier-desc">{msg.structured.tier_description}</div>
+                  )}
+                  <div className="fa-stats-grid">
+                    {msg.structured.stats.map((s, j) =>
+                      s.divider ? (
+                        <div key={j} className="fa-stat-section-hdr">{s.title}</div>
+                      ) : (
+                        <div key={j} className="fa-stat-row">
+                          <span className="fa-stat-label">{s.label}</span>
+                          <span className="fa-stat-value">{s.value}</span>
+                        </div>
+                      )
+                    )}
+                  </div>
+                  {msg.structured.projected_stats?.length > 0 && (
+                    <div className="fa-stats-toggle-row">
+                      <button className="fa-stats-toggle-btn" onClick={() => toggleStats(i)}>
+                        {statsOpen[i] ? '▲ Hide Stats Projection' : '▼ View Stats Projection'}
+                      </button>
+                    </div>
+                  )}
+                  {statsOpen[i] && msg.structured.career_stats?.length > 0 && (
+                    <RBStatsPanel
+                      careerStats={msg.structured.career_stats}
+                      projectedStats={msg.structured.projected_stats}
+                    />
+                  )}
+                  {msg.structured.year_breakdown?.length > 0 && (
+                    <YearBreakdown rows={msg.structured.year_breakdown} />
+                  )}
+                  <div className="fa-reasoning">
+                    <p className="fa-reasoning-title">Reasoning</p>
+                    <p className="fa-reasoning-text">{msg.structured.reasoning}</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+          {loading && (
+            <div className="fa-msg fa-msg--assistant">
+              <div className="fa-msg-label">GM Agent</div>
+              <div className="fa-typing"><span /><span /><span /></div>
+            </div>
+          )}
+          <div ref={chatEndRef} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /* ─── Root ─── */
 function FreeAgency() {
   const [selectedPosition, setSelectedPosition] = useState(null);
@@ -1366,6 +1690,9 @@ function FreeAgency() {
   }
   if (selectedPosition === 'DI') {
     return <DIEvaluator onBack={() => setSelectedPosition(null)} />;
+  }
+  if (selectedPosition === 'HB') {
+    return <RBEvaluator onBack={() => setSelectedPosition(null)} />;
   }
   return <EDEvaluator onBack={() => setSelectedPosition(null)} />;
 }


### PR DESCRIPTION
Enhance rb_agent_graph.py to match ED/DI agent pattern with contract-year state, RB-specific age curve, composite grade (40% model + 60% stats), career stats extraction, year-by-year stat/valuation projections, and tiered signing decisions.

Add rb_main_api.py FastAPI service on port 8004 exposing /rb-players and /evaluate endpoints.

Wire Running Back into FreeAgency.jsx with a new RBEvaluator, stats panel, and position-picker entry.